### PR TITLE
Handle recursive descent for lists and scalars

### DIFF
--- a/src/json_path/walker.clj
+++ b/src/json_path/walker.clj
@@ -21,8 +21,14 @@
           (= (first operands) "*") (vec (vals (:current context)))
           :else ((keyword (first operands)) (:current context)))))
 
+(defn obj-vals [obj]
+  (cond
+    (seq? obj) obj
+    (map? obj) (filter map? (vals obj))
+    :else []))
+
 (defn obj-aggregator [obj]
-  (let [obj-vals (vec (filter map? (vals obj)))
+  (let [obj-vals (obj-vals obj)
         children (flatten (map obj-aggregator obj-vals))]
     (vec (concat obj-vals children))))
 

--- a/test/json_path/test/walker_test.clj
+++ b/test/json_path/test/walker_test.clj
@@ -54,6 +54,17 @@
                                              {:world "bar",
                                               :quuz {:world "zux"}},
                                              {:world "zux"}]
+  (walk [:path [[:all-children]]]
+        {:current
+         (list {:hello {:world "foo"}}
+               {:baz {:world "bar"}})}) => [[{:hello {:world "foo"}}
+                                             {:baz {:world "bar"}}]
+                                            {:hello {:world "foo"}}
+                                            {:baz {:world "bar"}}
+                                            {:world "foo"}
+                                            {:world "bar"}]
+  (walk [:path [[:all-children]]]
+        {:current "scalar"}) => ["scalar"]
   (walk [:selector [:index "1"]] {:current ["foo", "bar", "baz"]}) => "bar"
   (walk [:selector [:index "*"]] {:current [:a :b]}) => [:a :b]
   (walk [:selector [:filter [:eq


### PR DESCRIPTION
Hey Giles

```clojure
(at-path "$.." '({:name "first"} {:name "second"}))
```

Expected:
```clojure
[({:name "first"} {:name "second"}) {:name "first"} {:name "second"}]
```

Actual
```
ClassCastException clojure.lang.PersistentArrayMap cannot be cast to java.util.Map$Entry  clojure.lang.APersistentMap$ValSeq.first (APersistentMap.java:183)
```

Similar behaviour for `(at-path "$.." "scalar")`.

This commit implements handling for both lists and scalars, cross-checked against http://jsonpath.com/.

Should you merge this, please also consider releasing a new version to clojars.