### PR TITLE
Handle vectors in recursive descent

### DIFF
--- a/src/json_path/walker.clj
+++ b/src/json_path/walker.clj
@@ -23,7 +23,7 @@
 
 (defn obj-vals [obj]
   (cond
-    (seq? obj) obj
+    (sequential? obj) obj
     (map? obj) (filter #(or (map? %) (sequential? %)) (vals obj))
     :else []))
 

--- a/test/json_path/test/walker_test.clj
+++ b/test/json_path/test/walker_test.clj
@@ -30,7 +30,8 @@
                                                                               {:qux "zoo"}]
   (walk-path [[:all-children] [:key "bar"]]
              {:current {:foo [{:bar "wrong"}
-                              {:bar "baz"}]}}) => ["wrong" "baz"])
+                              {:bar "baz"}]}}) => ["wrong" "baz"]
+  (walk-path [[:all-children]] {:current [{:foo "bar"}]}) => [[{:foo "bar"}] {:foo "bar"}])
 
 (fact
   (walk-selector [:index "1"] {:current ["foo", "bar", "baz"]}) => "bar"


### PR DESCRIPTION
Support vectors (e.g. `(at-path "$.." [{:name "first"} {:name "second"}])`) , follow-up to #3.

Now, before you consider merging this - this change will brake the test in #5. 

```
FAIL at (walker_test.clj:31)
    Expected: ["wrong" "baz"]
      Actual: ["wrong" "baz" "wrong" "baz"]
```

This is due to the recursive descent implementation rolling out all the candidate children, and then json-path doing more than the spec requests in my understanding with finding keys inside lists: https://github.com/gga/json-path/blob/master/test/json_path/test/walker_test.clj#L24.

Let me know if I've misunderstood the linked test. I'm currently working on a PR to implement #4, this might provide a basis to solve the issue mentioned here.