### PR TITLE
Feature: query keys alongside values

### DIFF
--- a/src/json_path.clj
+++ b/src/json_path.clj
@@ -2,6 +2,8 @@
   [:require [json-path.parser :as parser]
    [json-path.walker :as walker]])
 
+(defn query [path object]
+  (walker/walk (parser/parse-path path) {:root object}))
+
 (defn at-path [path object]
-  (let [result (walker/walk (parser/parse-path path) {:root object})]
-    (walker/map# first result)))
+  (walker/map# first (query path object)))

--- a/src/json_path.clj
+++ b/src/json_path.clj
@@ -3,4 +3,5 @@
    [json-path.walker :as walker]])
 
 (defn at-path [path object]
-  (walker/walk (parser/parse-path path) {:root object}))
+  (let [result (walker/walk (parser/parse-path path) {:root object})]
+    (walker/map# first result)))

--- a/src/json_path/walker.clj
+++ b/src/json_path/walker.clj
@@ -2,6 +2,11 @@
 
 (declare walk eval-expr)
 
+(defn map# [func obj]
+  (if (seq? obj)
+    (map func obj)
+    (func obj)))
+
 (defn eval-eq-expr [op-form context operands]
   (apply op-form (map #(eval-expr % context) operands)))
 
@@ -10,52 +15,73 @@
     (cond
      (contains? ops expr-type) (eval-eq-expr (expr-type ops) context operands)
      (= expr-type :val) (first operands)
-     (= expr-type :path) (walk expr context))))
+     (= expr-type :path) (first (walk expr context)))))
+
+(defn- with-parent-key [parent-key selection]
+  (map# (fn [[value key]] [value (vec (concat parent-key key))]) selection))
+
+(defn- map-selection [func selection]
+  (let [sub-selection (map# (fn [[val key]] (with-parent-key key (func val))) selection)]
+    (if (seq? (first sub-selection))
+      (apply concat sub-selection)
+      sub-selection)))
 
 (defn select-by [[opcode & operands :as obj-spec] context]
   (cond
-   (sequential? (:current context)) (vec (flatten (filter #(not (empty? %))
-                                                          (map #(select-by obj-spec (assoc context :current %))
-                                                               (:current context)))))
+   (sequential? (:current context)) (let [sub-selection (->> (:current context)
+                                                             (map #(select-by obj-spec (assoc context :current %)))
+                                                             (map-indexed (fn [i sel] (map# (fn [[obj key]] [obj (vec (cons i key))]) sel)))
+                                                             (filter #(not (empty? (first %)))))]
+                                      (if (seq? (first sub-selection))
+                                        (apply concat sub-selection)
+                                        sub-selection))
    :else (cond
-          (= (first operands) "*") (vec (vals (:current context)))
-          :else ((keyword (first operands)) (:current context)))))
+          (= (first operands) "*") (map (fn [[k v]] [v [k]]) (:current context))
+          :else (let [key (keyword (first operands))]
+                  [(key (:current context)) [key]]))))
 
 (defn obj-vals [obj]
   (cond
-    (seq? obj) obj
-    (map? obj) (filter #(or (map? %) (sequential? %)) (vals obj))
-    :else []))
+    (seq? obj) (map-indexed (fn [idx child-obj] [child-obj [idx]]) obj)
+    (map? obj) (->> obj
+                    (filter (fn [[k v]] (or (map? v) (sequential? v))))
+                    (map (fn [[k v]] [v [k]])))
+    :else '()))
 
 (defn obj-aggregator [obj]
   (let [obj-vals (obj-vals obj)
-        children (flatten (map obj-aggregator obj-vals))]
-    (vec (concat obj-vals children))))
+        children (map-selection obj-aggregator obj-vals)]
+    (concat obj-vals children)))
 
 (defn walk-path [[next & parts] context]
   (cond
-   (nil? next) (:current context)
+   (nil? next) [(:current context) []]
    (= [:root] next) (walk-path parts (assoc context :current (:root context)))
    (= [:child] next) (walk-path parts context)
    (= [:current] next) (walk-path parts context)
-   (= [:all-children] next) (walk-path parts (assoc context :current (vec (concat [(:current context)]
-                                                                                  (obj-aggregator (:current context))))))
-   (= :key (first next)) (walk-path parts (assoc context :current (select-by next context)))))
+   (= [:all-children] next) (let [all-children (cons [(:current context) []]
+                                                     (obj-aggregator (:current context)))]
+                              (->> all-children
+                                   (map-selection #(walk-path parts (assoc context :current %)))
+                                   (filter #(not (empty? (first %))))))
+   (= :key (first next)) (map-selection #(walk-path parts (assoc context :current %)) (select-by next context))))
 
 (defn walk-selector [sel-expr context]
   (cond
    (= :index (first sel-expr)) (if (sequential? (:current context))
                                  (let [sel (nth sel-expr 1)]
                                    (if (= "*" sel)
-                                     (:current context)
-                                     (nth (:current context) (Integer/parseInt sel))))
+                                     (map-indexed (fn [idx child-obj] [child-obj [idx]]) (:current context))
+                                     (let [index (Integer/parseInt sel)]
+                                       [(nth (:current context) index) [index]])))
                                  (throw (Exception. "object must be an array.")))
-   (= :filter (first sel-expr)) (filter #(eval-expr (nth sel-expr 1) (assoc context :current %)) (:current context))))
+   (= :filter (first sel-expr)) (keep-indexed (fn [i e] (if (eval-expr (nth sel-expr 1) (assoc context :current e)) [e [i]]))
+                                              (:current context))))
 
 (defn walk [[opcode operand continuation] context]
   (let [down-obj (cond
          (= opcode :path) (walk-path operand context)
          (= opcode :selector) (walk-selector operand context))]
     (if continuation
-      (walk continuation (assoc context :current down-obj))
+      (map-selection #(walk continuation (assoc context :current %)) down-obj)
       down-obj)))

--- a/src/json_path/walker.clj
+++ b/src/json_path/walker.clj
@@ -22,8 +22,13 @@
 
 (defn- map-selection [func selection]
   (let [sub-selection (map# (fn [[val key]] (with-parent-key key (func val))) selection)]
-    (if (seq? (first sub-selection))
-      (apply concat sub-selection)
+    (if (seq? sub-selection)
+      (->> sub-selection
+           (reduce (fn [col item] (if (seq? item)
+                                    (concat col item)
+                                    (conj col item)))
+                   [])
+           seq)
       sub-selection)))
 
 (defn select-by [[opcode & operands :as obj-spec] context]

--- a/test/json_path/test/json_path_test.clj
+++ b/test/json_path/test/json_path_test.clj
@@ -21,3 +21,13 @@
   (at-path "$.foo[?(@.id=$.id)].text"
            {:id 45, :foo [{:id 12, :text "bar"},
                           {:id 45, :text "hello"}]}) => ["hello"])
+
+(facts
+ (query "$..world" {:baz {:world "bar",
+                          :quuz {:world "zux"}}})  => '(["bar" [:baz :world]] ["zux" [:baz :quuz :world]])
+ (query "$.foo[*]" {:foo ["a", "b", "c"]}) => '(["a" [:foo 0]] ["b" [:foo 1]] ["c" [:foo 2]])
+ (query "$.hello" {:hello "world"}) => ["world" [:hello]]
+ (query "$" {:hello "world"}) => [{:hello "world"} []]
+ (query "$.foo[?(@.bar=\"baz\")].hello"
+        {:foo [{:bar "wrong" :hello "goodbye"}
+               {:bar "baz" :hello "world"}]}) => '(["world" [:foo 1 :hello]]))

--- a/test/json_path/test/walker_test.clj
+++ b/test/json_path/test/walker_test.clj
@@ -16,66 +16,81 @@
   (eval-expr [:eq [:path [[:key "foo"]]] [:val "bar"]] {:current {:foo "bar"}}) => truthy)
 
 (facts
-  (select-by [:key "hello"] {:current {:hello "world"}}) => "world"
-  (select-by [:key "hello"] {:current [{:hello "foo"} {:hello "bar"}]}) => ["foo" "bar"]
-  (select-by [:key "hello"] {:current [{:blah "foo"} {:hello "bar"}]}) => [ "bar"]
-  (select-by [:key "*"] {:current {:hello "world"}}) => ["world"]
-  (sort (select-by [:key "*"] {:current {:hello "world", :foo "bar"}})) => ["bar", "world"]
-  (sort (select-by [:key "*"] {:current [{:hello "world"}, {:foo "bar"}]})) => ["bar", "world"])
+  (select-by [:key "hello"] {:current {:hello "world"}}) => ["world" [:hello]]
+  (select-by [:key "hello"] {:current [{:hello "foo"} {:hello "bar"}]}) => '(["foo" [0 :hello]] ["bar" [1 :hello]])
+  (select-by [:key "hello"] {:current [{:blah "foo"} {:hello "bar"}]}) => '(["bar" [1 :hello]])
+  (select-by [:key "*"] {:current {:hello "world"}}) => '(["world" [:hello]])
+  (sort-by first (select-by [:key "*"] {:current {:hello "world" :foo "bar"}})) => '(["bar" [:foo]] ["world" [:hello]])
+  (sort-by first (select-by [:key "*"] {:current [{:hello "world"} {:foo "bar"}]})) => '(["bar" [1 :foo]] ["world" [0 :hello]]))
 
 (fact
-  (walk-path [[:root]] {:root ...root..., :current  ...obj...}) => ...root...
-  (walk-path [[:root] [:child] [:key "foo"]] {:root {:foo "bar"}}) => "bar"
-  (walk-path [[:all-children]] {:current {:foo "bar" :baz {:qux "zoo"}}}) => [{:foo "bar" :baz {:qux "zoo"}},
-                                                                              {:qux "zoo"}]
-  (walk-path [[:all-children] [:key "bar"]]
-             {:current {:foo [{:bar "wrong"}
-                              {:bar "baz"}]}}) => ["wrong" "baz"])
+  (walk-path [[:root]] {:root ...root..., :current  ...obj...}) => [...root... []]
+  (walk-path [[:root] [:child] [:key "foo"]] {:root {:foo "bar"}}) => ["bar" [:foo]]
+  (walk-path [[:key "foo"]] {:current [{:foo "bar"} {:foo "baz"} {:foo "qux"}]}) => '(["bar" [0 :foo]] ["baz" [1 :foo]] ["qux" [2 :foo]])
+  (walk-path [[:all-children]] {:current {:foo "bar" :baz {:qux "zoo"}}}) => '([{:foo "bar" :baz {:qux "zoo"}} []]
+                                                                               [{:qux "zoo"} [:baz]])
+  (distinct (walk-path [[:all-children] [:key "bar"]] ;; distinct works around dups, mentioned in https://github.com/gga/json-path/pull/6
+                       {:current '([{:bar "hello"}])})) => '(["hello" [0 0 :bar]]))
 
 (fact
-  (walk-selector [:index "1"] {:current ["foo", "bar", "baz"]}) => "bar"
-  (walk-selector [:index "*"] {:current [:a :b]}) => [:a :b]
+  (walk-selector [:index "1"] {:current ["foo", "bar", "baz"]}) => ["bar" [1]]
+  (walk-selector [:index "*"] {:current [:a :b]}) => '([:a [0]] [:b [1]])
   (walk-selector [:filter [:eq [:path [[:current] [:child] [:key "bar"]]] [:val "baz"]]]
-                 {:current  [{:bar "wrong"} {:bar "baz"}]}) => [{:bar "baz"}])
+                 {:current  [{:bar "wrong"} {:bar "baz"}]}) => '([{:bar "baz"} [1]]))
 
 (fact "selecting places constraints on the shape of the object being selected from"
   (walk-selector [:index "1"] {:current {:foo "bar"}}) => (throws Exception)
   (walk-selector [:index "*"] {:current {:foo "bar"}}) => (throws Exception))
 
 (facts
-  (walk [:path [[:root]]] {:root ...json...}) => ...json...
-  (walk [:path [[:child]]] {:current ...json...}) => ...json...
-  (walk [:path [[:current]]] {:current ...json...}) => ...json...
-  (walk [:path [[:key "foo"]]] {:current {:foo "bar"}}) => "bar"
+  (walk [:path [[:root]]] {:root ...json...}) => [...json... []]
+  (walk [:path [[:child]]] {:current ...json...}) => [...json... []]
+  (walk [:path [[:current]]] {:current ...json...}) => [...json... []]
+  (walk [:path [[:key "foo"]]] {:current {:foo "bar"}}) => ["bar" [:foo]]
   (walk [:path [[:all-children]]]
         {:current
          {:hello {:world "foo"},
           :baz {:world "bar",
-                :quuz {:world "zux"}}}}) => [{:hello {:world "foo"},
-                                              :baz {:world "bar", :quuz {:world "zux"}}},
-                                             {:world "foo"},
-                                             {:world "bar",
-                                              :quuz {:world "zux"}},
-                                             {:world "zux"}]
+                :quuz {:world "zux"}}}}) => '([{:hello {:world "foo"},
+                                                :baz {:world "bar", :quuz {:world "zux"}}}
+                                               []]
+                                              [{:world "foo"}
+                                               [:hello]]
+                                              [{:world "bar",
+                                                :quuz {:world "zux"}}
+                                               [:baz]]
+                                              [{:world "zux"}
+                                               [:baz :quuz]])
   (walk [:path [[:all-children]]]
         {:current
          (list {:hello {:world "foo"}}
-               {:baz {:world "bar"}})}) => [[{:hello {:world "foo"}}
-                                             {:baz {:world "bar"}}]
-                                            {:hello {:world "foo"}}
-                                            {:baz {:world "bar"}}
-                                            {:world "foo"}
-                                            {:world "bar"}]
+               {:baz {:world "bar"}})}) => '([[{:hello {:world "foo"}}
+                                               {:baz {:world "bar"}}]
+                                              []]
+                                             [{:hello {:world "foo"}} [0]]
+                                             [{:baz {:world "bar"}} [1]]
+                                             [{:world "foo"} [0 :hello]]
+                                             [{:world "bar"} [1 :baz]])
   (walk [:path [[:all-children]]]
-        {:current "scalar"}) => ["scalar"]
-  (walk [:selector [:index "1"]] {:current ["foo", "bar", "baz"]}) => "bar"
-  (walk [:selector [:index "*"]] {:current [:a :b]}) => [:a :b]
+        {:current "scalar"}) => '(["scalar" []])
+  (walk [:path [[:all-children] [:key "world"]]]
+        {:current {:hello {:world "foo"},
+                   :baz   {:world "bar",
+                           :quuz {:world "zux"}}}}) => '(["foo" [:hello :world]]
+                                                         ["bar" [:baz :world]]
+                                                         ["zux" [:baz :quuz :world]])
+  (walk [:selector [:index "1"]] {:current ["foo", "bar", "baz"]}) => ["bar" [1]]
+  (walk [:selector [:index "*"]] {:current [:a :b]}) => '([:a [0]] [:b [1]])
+  (walk [:selector [:index "*"]
+         [:path [[:child] [:key "foo"]]]]
+        {:current
+         [{:foo 1} {:foo 2}]}) => '([1 [0 :foo]] [2 [1 :foo]])
   (walk [:selector [:filter [:eq
                              [:path [[:current]
                                      [:child]
                                      [:key "bar"]]]
                              [:val "baz"]]]]
-        {:current [{:bar "wrong"} {:bar "baz"}]}) => [{:bar "baz"}]
+        {:current [{:bar "wrong"} {:bar "baz"}]}) => '([{:bar "baz"} [1]])
   (walk [:path [[:root] [:child] [:key "foo"]]
          [:selector [:filter [:eq [:path [[:current]
                                           [:child]
@@ -83,10 +98,10 @@
                               [:val "baz"]]]
           [:path [[:child] [:key "hello"]]]]]
         {:root {:foo [{:bar "wrong" :hello "goodbye"}
-                      {:bar "baz" :hello "world"}]}}) => ["world"])
+                      {:bar "baz" :hello "world"}]}}) => '(["world" [:foo 1 :hello]]))
 
 (facts "walking a nil object should be safe"
-  (walk [:path [[:root]]] nil) => nil
-  (walk [:path [[:root] [:child] [:key "foo"]]] {:bar "baz"}) => nil
+  (walk [:path [[:root]]] nil) => [nil []]
+  (walk [:path [[:root] [:child] [:key "foo"]]] {:bar "baz"}) => [nil [:foo]]
   (walk [:path [[:root] [:child] [:key "foo"] [:child] [:key "bar"]]]
-        {:foo {:baz "hello"}}) => nil)
+           {:foo {:baz "hello"}}) => [nil [:foo :bar]])

--- a/test/json_path/test/walker_test.clj
+++ b/test/json_path/test/walker_test.clj
@@ -30,7 +30,14 @@
   (walk-path [[:all-children]] {:current {:foo "bar" :baz {:qux "zoo"}}}) => '([{:foo "bar" :baz {:qux "zoo"}} []]
                                                                                [{:qux "zoo"} [:baz]])
   (distinct (walk-path [[:all-children] [:key "bar"]] ;; distinct works around dups, mentioned in https://github.com/gga/json-path/pull/6
-                       {:current '([{:bar "hello"}])})) => '(["hello" [0 0 :bar]]))
+                       {:current '([{:bar "hello"}])})) => '(["hello" [0 0 :bar]])
+  (walk-path [[:all-children] [:key "bar"]]
+             {:current {:foo [{:bar "wrong"}
+                              {:bar "baz"}]}}) => '(["wrong" [:foo 0 :bar]]
+                                                    ["baz" [:foo 1 :bar]])
+  (walk-path [[:all-children] [:key "foo"]]
+             {:current {:foo [{:foo "foo"}]}}) => '([[{:foo "foo"}] [:foo]]
+                                                    ["foo" [:foo 0 :foo]]))
 
 (fact
   (walk-selector [:index "1"] {:current ["foo", "bar", "baz"]}) => ["bar" [1]]


### PR DESCRIPTION
This PR implements a separate API to retrieve the key sequence as understood by Clojure's own `get-in` alongside matches. This is motivated by #4.

The new function is called `query` for now for lack of a better name.

The implementation is rather straightforward. For every method that returns a match, wrap this in a vector with the second part consisting of the vector of keys, which `get-in` would need to retrieve said match, e.g. `["world" [:key 1]]`.

To achieve this, `walk` will now return a list for multiple matches (rather than a vector), without any impact on the existing external API.

Internally, the library previously handled traversing on multiple matches by treating the intermediate match list as the object iterated on. This is now changed to multiple traverses, one for each intermediate match, so that the key can be correctly attributed. 

The challenging aspect was to be able to handle both a scalar and a list match in any situation.

One outcome of this change could be to drop the query by key of nested list structures as implemented in https://github.com/gga/json-path/compare/master...cburgmer:with-key?expand=1#diff-f6f649555c89d7e100dfb151a6b92f65R31, but I'll address this in a separate issue.

Happy about feedback