### PR TITLE
Unify $.* and $[*] and don't resolve key lookup for list of maps

### DIFF
--- a/test/json_path/test/walker_test.clj
+++ b/test/json_path/test/walker_test.clj
@@ -42,12 +42,13 @@
 (facts
   (walk-selector [:index "1"] {:current (m/root ["foo", "bar", "baz"])}) => (m/create "bar" [1])
   (walk-selector [:index "*"] {:current (m/root [:a :b])}) => (list (m/create :a [0]) (m/create :b [1]))
+  (walk-selector [:index "*"] {:current (m/root {:foo "bar"})}) => (list (m/create "bar" [:foo]))
+  (walk-selector [:index "*"] {:current (m/root 1)}) => '()
   (walk-selector [:filter [:eq [:path [[:current] [:child] [:key "bar"]]] [:val "baz"]]]
                  {:current (m/root [{:bar "wrong"} {:bar "baz"}])}) => (list (m/create {:bar "baz"} [1])))
 
 (fact "selecting places constraints on the shape of the object being selected from"
-  (walk-selector [:index "1"] {:current (m/root {:foo "bar"})}) => (throws Exception)
-  (walk-selector [:index "*"] {:current (m/root {:foo "bar"})}) => (throws Exception))
+  (walk-selector [:index "1"] {:current (m/root {:foo "bar"})}) => (throws Exception))
 
 (facts
   (walk [:path [[:root]]] {:root (m/root ...json...)}) => (m/create ...json... [])

--- a/test/json_path/test/walker_test.clj
+++ b/test/json_path/test/walker_test.clj
@@ -18,22 +18,19 @@
 
 (facts
   (select-by [:key "hello"] (m/root {:hello "world"})) => (m/create "world" [:hello])
-  (select-by [:key "hello"] (m/root [{:hello "foo"} {:hello "bar"}])) => (list (m/create "foo" [0 :hello]) (m/create "bar" [1 :hello]))
-  (select-by [:key "hello"] (m/root [{:blah "foo"} {:hello "bar"}])) => (list (m/create "bar" [1 :hello]))
+  (select-by [:key "hello"] {:current [{:hello "foo"} {:hello "bar"}]}) => (m/create nil [:hello])
   (select-by [:key "*"] (m/root {:hello "world"})) => (list (m/create "world" [:hello]))
-  (sort-by first (select-by [:key "*"] (m/root {:hello "world" :foo "bar"}))) => (list (m/create "bar" [:foo]) (m/create "world" [:hello]))
-  (sort-by first (select-by [:key "*"] (m/root [{:hello "world"} {:foo "bar"}]))) => (list (m/create "world" [0 :hello]) (m/create "bar" [1 :foo])))
+  (select-by [:key "*"] (m/root {:hello "world" :foo "bar"})) => (list (m/create "bar" [:foo]) (m/create "world" [:hello]))
+  (select-by [:key "*"] (m/root [{:hello "world"} {:foo "bar"}])) => (list (m/create {:hello "world"} [0]) (m/create {:foo "bar"} [1]))
+  (select-by [:key "*"] {:current 1}) => '())
 
 (facts
   (walk-path [[:root]] {:root (m/root ...root...), :current  (m/root ...obj...)}) => (m/create ...root... [])
   (walk-path [[:root] [:child] [:key "foo"]] {:root (m/root {:foo "bar"})}) => (m/create "bar" [:foo])
-  (walk-path [[:key "foo"]] {:current (m/root [{:foo "bar"} {:foo "baz"} {:foo "qux"}])}) => (list (m/create "bar" [0 :foo])
-                                                                                                    (m/create "baz" [1 :foo])
-                                                                                                    (m/create "qux" [2 :foo]))
   (walk-path [[:all-children]] {:current (m/root {:foo "bar" :baz {:qux "zoo"}})}) => (list (m/create {:foo "bar" :baz {:qux "zoo"}} [])
                                                                                              (m/create {:qux "zoo"} [:baz]))
-  (distinct (walk-path [[:all-children] [:key "bar"]] ;; distinct works around dups, mentioned in https://github.com/gga/json-path/pull/6
-                       {:current (m/root '([{:bar "hello"}]))})) => (list (m/create "hello" [0 0 :bar]))
+  (walk-path [[:all-children] [:key "bar"]]
+             {:current (m/root '([{:bar "hello"}]))}) => (list (m/create "hello" [0 0 :bar]))
   (walk-path [[:all-children] [:key "bar"]]
              {:current (m/root {:foo [{:bar "wrong"}
                                        {:bar "baz"}]})}) => (list (m/create "wrong" [:foo 0 :bar])
@@ -95,6 +92,7 @@
          [:path [[:child] [:key "foo"]]]]
         {:current
          (m/root [{:foo 1} {:foo 2}])}) => (list (m/create 1 [0 :foo]) (m/create 2 [1 :foo]))
+  (walk [:path [[:key "*"]]] {:current 1}) => '()
   (walk [:selector [:filter [:eq
                              [:path [[:current]
                                      [:child]


### PR DESCRIPTION
This change set will unify behaviour for `$.*` and `$[*]` to apply the same semantics to both lists and maps *and* will stop resolving `$.key` for `[{:key "val"}]` (see #8). Even further, this will fix #6 to correctly handle vectors in `..` queries. 

```clj
(facts
 (at-path "$.*" 1) => nil
 (at-path "$[*]" 1) => nil
 (at-path "$.*" [1]) => '(1)
 (at-path "$[*]" [1]) => '(1)
 (at-path "$.*" {:foo "bar"}) => '("bar")
 (at-path "$[*]" {:foo "bar"}) => '("bar"))
```

And
```clj
(facts
 (at-path "$.key" [{:key "val"}]) => nil)
(facts
 (at-path "$.key" {:key "val"}) => "val")
```

I read this behaviour out of http://goessner.net/articles/JsonPath/:

> x.store.book[0].title
> or
> x['store']['book'][0]['title']

The reason I put both changes into one PR is because they supplement each other well.

I believe there's another change waiting, for `$[0]` vs. `$.0` as well as `$[0]` not failing hard on anything besides lists. Will handle this independently.