### PR TITLE
Expose match as record, refactor aggregation of path

### DIFF
--- a/src/json_path.clj
+++ b/src/json_path.clj
@@ -7,4 +7,4 @@
   (walker/walk (parser/parse-path path) {:root (m/match object)}))
 
 (defn at-path [path object]
-  (walker/map# first (query path object)))
+  (walker/map# m/value (query path object)))

--- a/src/json_path.clj
+++ b/src/json_path.clj
@@ -4,7 +4,7 @@
    [json-path.walker :as walker]])
 
 (defn query [path object]
-  (walker/walk (parser/parse-path path) {:root (m/match object)}))
+  (walker/walk (parser/parse-path path) {:root (m/root object)}))
 
 (defn at-path [path object]
-  (walker/map# m/value (query path object)))
+  (walker/map# :value (query path object)))

--- a/src/json_path.clj
+++ b/src/json_path.clj
@@ -1,9 +1,10 @@
 (ns json-path
   [:require [json-path.parser :as parser]
+   [json-path.match :as m]
    [json-path.walker :as walker]])
 
 (defn query [path object]
-  (walker/walk (parser/parse-path path) {:root object}))
+  (walker/walk (parser/parse-path path) {:root (m/match object)}))
 
 (defn at-path [path object]
   (walker/map# first (query path object)))

--- a/src/json_path/match.clj
+++ b/src/json_path/match.clj
@@ -10,3 +10,6 @@
   ([value] [value []])
   ([key value] [value [key]])
   ([key value context] [value (vec (concat (path context) [key]))]))
+
+(defn create-match [value path]
+  [value path])

--- a/src/json_path/match.clj
+++ b/src/json_path/match.clj
@@ -2,17 +2,12 @@
 
 (defrecord Match [path value])
 
-(defn value [match]
-  (:value match))
+(defn root [value]
+  (->Match [] value))
 
-(defn- path [match]
-  (:path match))
-
-(defn match
-  ([value] (->Match [] value))
-  ([key value] (->Match [key] value))
-  ([key value context] (->Match (vec (concat (path context) [key]))
+(defn with-context
+  ([key value context] (->Match (vec (concat (:path context) [key]))
                                 value)))
 
-(defn create-match [value path]
+(defn create [value path]
   (->Match path value))

--- a/src/json_path/match.clj
+++ b/src/json_path/match.clj
@@ -1,15 +1,18 @@
 (ns json-path.match)
 
+(defrecord Match [path value])
+
 (defn value [match]
-  (first match))
+  (:value match))
 
 (defn- path [match]
-  (last match))
+  (:path match))
 
 (defn match
-  ([value] [value []])
-  ([key value] [value [key]])
-  ([key value context] [value (vec (concat (path context) [key]))]))
+  ([value] (->Match [] value))
+  ([key value] (->Match [key] value))
+  ([key value context] (->Match (vec (concat (path context) [key]))
+                                value)))
 
 (defn create-match [value path]
-  [value path])
+  (->Match path value))

--- a/src/json_path/match.clj
+++ b/src/json_path/match.clj
@@ -1,0 +1,12 @@
+(ns json-path.match)
+
+(defn value [match]
+  (first match))
+
+(defn- path [match]
+  (last match))
+
+(defn match
+  ([value] [value []])
+  ([key value] [value [key]])
+  ([key value context] [value (vec (concat (path context) [key]))]))

--- a/src/json_path/walker.clj
+++ b/src/json_path/walker.clj
@@ -11,7 +11,7 @@
     (cond
      (contains? ops expr-type) (eval-eq-expr (expr-type ops) context operands)
      (= expr-type :val) (first operands)
-     (= expr-type :path) (first (walk expr context)))))
+     (= expr-type :path) (m/value (walk expr context)))))
 
 (defn map# [func obj]
   (if (seq? obj)
@@ -32,9 +32,9 @@
   (let [obj (m/value current-context)]
     (cond
       (sequential? obj) (->> (map-indexed (fn [idx child-obj] (m/match idx child-obj current-context)) obj)
-                                  (map #(select-by obj-spec %))
-                                  (filter #(not (empty? (m/value %))))
-                                  join-matches)
+                             (map #(select-by obj-spec %))
+                             join-matches
+                             (filter #(not (empty? (m/value %)))))
       :else (cond
               (= (first operands) "*") (map (fn [[k v]] (m/match k v current-context)) obj)
               :else (let [key (keyword (first operands))]
@@ -63,7 +63,7 @@
                                  all-children
                                  (map# #(walk-path parts (assoc context :current %)))
                                  join-matches
-                                 (filter #(not (empty? (first %)))))
+                                 (filter #(not (empty? (m/value %)))))
    (= :key (first next)) (join-matches (map# #(walk-path parts (assoc context :current %)) (select-by next (:current context))))))
 
 (defn walk-selector [sel-expr context]

--- a/src/json_path/walker.clj
+++ b/src/json_path/walker.clj
@@ -1,11 +1,7 @@
-(ns json-path.walker)
+(ns json-path.walker
+  [:require [json-path.match :as m]])
 
 (declare walk eval-expr)
-
-(defn map# [func obj]
-  (if (seq? obj)
-    (map func obj)
-    (func obj)))
 
 (defn eval-eq-expr [op-form context operands]
   (apply op-form (map #(eval-expr % context) operands)))
@@ -17,74 +13,77 @@
      (= expr-type :val) (first operands)
      (= expr-type :path) (first (walk expr context)))))
 
-(defn- with-parent-key [parent-key selection]
-  (map# (fn [[value key]] [value (vec (concat parent-key key))]) selection))
+(defn map# [func obj]
+  (if (seq? obj)
+    (map func obj)
+    (func obj)))
 
-(defn- map-selection [func selection]
-  (let [sub-selection (map# (fn [[val key]] (with-parent-key key (func val))) selection)]
-    (if (seq? sub-selection)
-      (->> sub-selection
-           (reduce (fn [col item] (if (seq? item)
-                                    (concat col item)
-                                    (conj col item)))
-                   [])
-           seq)
-      sub-selection)))
+(defn- join-matches [selections]
+  (if (seq? selections)
+    (->> selections
+         (reduce (fn [col item] (if (seq? item)
+                                  (concat col item)
+                                  (conj col item)))
+                 [])
+         seq)
+    selections))
 
-(defn select-by [[opcode & operands :as obj-spec] context]
-  (cond
-   (sequential? (:current context)) (let [sub-selection (->> (:current context)
-                                                             (map #(select-by obj-spec (assoc context :current %)))
-                                                             (map-indexed (fn [i sel] (map# (fn [[obj key]] [obj (vec (cons i key))]) sel)))
-                                                             (filter #(not (empty? (first %)))))]
-                                      (if (seq? (first sub-selection))
-                                        (apply concat sub-selection)
-                                        sub-selection))
-   :else (cond
-          (= (first operands) "*") (map (fn [[k v]] [v [k]]) (:current context))
-          :else (let [key (keyword (first operands))]
-                  [(key (:current context)) [key]]))))
+(defn select-by [[opcode & operands :as obj-spec] current-context]
+  (let [obj (m/value current-context)]
+    (cond
+      (sequential? obj) (->> (map-indexed (fn [idx child-obj] (m/match idx child-obj current-context)) obj)
+                                  (map #(select-by obj-spec %))
+                                  (filter #(not (empty? (m/value %))))
+                                  join-matches)
+      :else (cond
+              (= (first operands) "*") (map (fn [[k v]] (m/match k v current-context)) obj)
+              :else (let [key (keyword (first operands))]
+                      (m/match key (key obj) current-context))))))
 
-(defn obj-vals [obj]
-  (cond
-    (seq? obj) (map-indexed (fn [idx child-obj] [child-obj [idx]]) obj)
-    (map? obj) (->> obj
-                    (filter (fn [[k v]] (or (map? v) (sequential? v))))
-                    (map (fn [[k v]] [v [k]])))
-    :else '()))
+(defn- obj-vals [current-context]
+  (let [obj (m/value current-context)]
+    (cond
+      (seq? obj) (map-indexed (fn [idx child-obj] (m/match idx child-obj current-context)) obj)
+      (map? obj) (->> obj
+                      (filter (fn [[k v]] (or (map? v) (sequential? v))))
+                      (map (fn [[k v]] (m/match k v current-context))))
+      :else '())))
 
-(defn all-children [obj]
-  (let [children (map-selection all-children (obj-vals obj))]
-    (concat (list [obj []]) children)))
+(defn- all-children [current-context]
+  (let [children (mapcat all-children (obj-vals current-context))]
+    (cons current-context children)))
 
 (defn walk-path [[next & parts] context]
   (cond
-   (nil? next) [(:current context) []]
+   (nil? next) (:current context)
    (= [:root] next) (walk-path parts (assoc context :current (:root context)))
    (= [:child] next) (walk-path parts context)
    (= [:current] next) (walk-path parts context)
    (= [:all-children] next) (->> (:current context)
                                  all-children
-                                 (map-selection #(walk-path parts (assoc context :current %)))
+                                 (map# #(walk-path parts (assoc context :current %)))
+                                 join-matches
                                  (filter #(not (empty? (first %)))))
-   (= :key (first next)) (map-selection #(walk-path parts (assoc context :current %)) (select-by next context))))
+   (= :key (first next)) (join-matches (map# #(walk-path parts (assoc context :current %)) (select-by next (:current context))))))
 
 (defn walk-selector [sel-expr context]
   (cond
-   (= :index (first sel-expr)) (if (sequential? (:current context))
-                                 (let [sel (nth sel-expr 1)]
-                                   (if (= "*" sel)
-                                     (map-indexed (fn [idx child-obj] [child-obj [idx]]) (:current context))
-                                     (let [index (Integer/parseInt sel)]
-                                       [(nth (:current context) index) [index]])))
-                                 (throw (Exception. "object must be an array.")))
-   (= :filter (first sel-expr)) (keep-indexed (fn [i e] (if (eval-expr (nth sel-expr 1) (assoc context :current e)) [e [i]]))
-                                              (:current context))))
+    (= :index (first sel-expr)) (let [obj (m/value (:current context))
+                                      sel (nth sel-expr 1)]
+                                  (if (sequential? obj)
+                                    (if (= "*" sel)
+                                      (map-indexed (fn [idx child-obj] (m/match idx child-obj (:current context))) obj)
+                                      (let [index (Integer/parseInt sel)]
+                                        (m/match index (nth obj index) (:current context))))
+                                    (throw (Exception. "object must be an array."))))
+   (= :filter (first sel-expr)) (keep-indexed (fn [i e] (if (eval-expr (nth sel-expr 1) (assoc context :current (m/match e)))
+                                                          (m/match i e (:current context))))
+                                              (m/value (:current context)))))
 
 (defn walk [[opcode operand continuation] context]
   (let [down-obj (cond
          (= opcode :path) (walk-path operand context)
          (= opcode :selector) (walk-selector operand context))]
     (if continuation
-      (map-selection #(walk continuation (assoc context :current %)) down-obj)
+      (map# #(walk continuation (assoc context :current %)) down-obj)
       down-obj)))

--- a/test/json_path/test/json_path_test.clj
+++ b/test/json_path/test/json_path_test.clj
@@ -1,4 +1,5 @@
 (ns json-path.test.json-path-test
+  [:require [json-path.match :as m]]
   [:use [json-path]
    [midje.sweet]])
 
@@ -24,10 +25,12 @@
 
 (facts
  (query "$..world" {:baz {:world "bar",
-                          :quuz {:world "zux"}}})  => '(["bar" [:baz :world]] ["zux" [:baz :quuz :world]])
- (query "$.foo[*]" {:foo ["a", "b", "c"]}) => '(["a" [:foo 0]] ["b" [:foo 1]] ["c" [:foo 2]])
- (query "$.hello" {:hello "world"}) => ["world" [:hello]]
- (query "$" {:hello "world"}) => [{:hello "world"} []]
+                          :quuz {:world "zux"}}})  => (list (m/create-match "bar" [:baz :world]) (m/create-match "zux" [:baz :quuz :world]))
+ (query "$.foo[*]" {:foo ["a", "b", "c"]}) => (list (m/create-match "a" [:foo 0])
+                                                    (m/create-match "b" [:foo 1])
+                                                    (m/create-match "c" [:foo 2]))
+ (query "$.hello" {:hello "world"}) => (m/create-match "world" [:hello])
+ (query "$" {:hello "world"}) => (m/create-match {:hello "world"} [])
  (query "$.foo[?(@.bar=\"baz\")].hello"
         {:foo [{:bar "wrong" :hello "goodbye"}
-               {:bar "baz" :hello "world"}]}) => '(["world" [:foo 1 :hello]]))
+               {:bar "baz" :hello "world"}]}) => (list (m/create-match "world" [:foo 1 :hello])))

--- a/test/json_path/test/json_path_test.clj
+++ b/test/json_path/test/json_path_test.clj
@@ -25,12 +25,12 @@
 
 (facts
  (query "$..world" {:baz {:world "bar",
-                          :quuz {:world "zux"}}})  => (list (m/create-match "bar" [:baz :world]) (m/create-match "zux" [:baz :quuz :world]))
- (query "$.foo[*]" {:foo ["a", "b", "c"]}) => (list (m/create-match "a" [:foo 0])
-                                                    (m/create-match "b" [:foo 1])
-                                                    (m/create-match "c" [:foo 2]))
- (query "$.hello" {:hello "world"}) => (m/create-match "world" [:hello])
- (query "$" {:hello "world"}) => (m/create-match {:hello "world"} [])
+                          :quuz {:world "zux"}}})  => (list (m/create "bar" [:baz :world]) (m/create "zux" [:baz :quuz :world]))
+ (query "$.foo[*]" {:foo ["a", "b", "c"]}) => (list (m/create "a" [:foo 0])
+                                                    (m/create "b" [:foo 1])
+                                                    (m/create "c" [:foo 2]))
+ (query "$.hello" {:hello "world"}) => (m/create "world" [:hello])
+ (query "$" {:hello "world"}) => (m/create {:hello "world"} [])
  (query "$.foo[?(@.bar=\"baz\")].hello"
         {:foo [{:bar "wrong" :hello "goodbye"}
-               {:bar "baz" :hello "world"}]}) => (list (m/create-match "world" [:foo 1 :hello])))
+               {:bar "baz" :hello "world"}]}) => (list (m/create "world" [:foo 1 :hello])))

--- a/test/json_path/test/json_path_test.clj
+++ b/test/json_path/test/json_path_test.clj
@@ -1,5 +1,4 @@
 (ns json-path.test.json-path-test
-  [:require [json-path.match :as m]]
   [:use [json-path]
    [midje.sweet]])
 
@@ -24,13 +23,24 @@
                           {:id 45, :text "hello"}]}) => ["hello"])
 
 (facts
- (query "$..world" {:baz {:world "bar",
-                          :quuz {:world "zux"}}})  => (list (m/create "bar" [:baz :world]) (m/create "zux" [:baz :quuz :world]))
- (query "$.foo[*]" {:foo ["a", "b", "c"]}) => (list (m/create "a" [:foo 0])
-                                                    (m/create "b" [:foo 1])
-                                                    (m/create "c" [:foo 2]))
- (query "$.hello" {:hello "world"}) => (m/create "world" [:hello])
- (query "$" {:hello "world"}) => (m/create {:hello "world"} [])
- (query "$.foo[?(@.bar=\"baz\")].hello"
-        {:foo [{:bar "wrong" :hello "goodbye"}
-               {:bar "baz" :hello "world"}]}) => (list (m/create "world" [:foo 1 :hello])))
+  (-> (query "$.hello"
+             {:hello "world"})
+      :path) => [:hello]
+  (-> (query "$"
+             {:hello "world"})
+      :path) => []
+  (->> (query "$..world" {:baz {:world "bar",
+                                :quuz {:world "zux"}}})
+       (map :value))  => '("bar" "zux")
+  (->> (query "$..world" {:baz {:world "bar",
+                                :quuz {:world "zux"}}})
+       (map :path))  => '([:baz :world] [:baz :quuz :world])
+  (->> (query "$.foo[*]" {:foo ["a", "b", "c"]})
+       (map :path)) => '([:foo 0] [:foo 1] [:foo 2])
+  (-> (query "$.hello"
+             {:hello "world"})
+      :value) => "world"
+  (->> (query "$.foo[?(@.bar=\"baz\")].hello"
+              {:foo [{:bar "wrong" :hello "goodbye"}
+                     {:bar "baz" :hello "world"}]})
+       (map :path)) => '([:foo 1 :hello]))

--- a/test/json_path/test/walker_test.clj
+++ b/test/json_path/test/walker_test.clj
@@ -17,88 +17,88 @@
   (eval-expr [:eq [:path [[:key "foo"]]] [:val "bar"]] {:current (m/match {:foo "bar"})}) => truthy)
 
 (facts
-  (select-by [:key "hello"] (m/match {:hello "world"})) => ["world" [:hello]]
-  (select-by [:key "hello"] (m/match [{:hello "foo"} {:hello "bar"}])) => '(["foo" [0 :hello]] ["bar" [1 :hello]])
-  (select-by [:key "hello"] (m/match [{:blah "foo"} {:hello "bar"}])) => '(["bar" [1 :hello]])
-  (select-by [:key "*"] (m/match {:hello "world"})) => '(["world" [:hello]])
-  (sort-by first (select-by [:key "*"] (m/match {:hello "world" :foo "bar"}))) => '(["bar" [:foo]] ["world" [:hello]])
-  (sort-by first (select-by [:key "*"] (m/match [{:hello "world"} {:foo "bar"}]))) => '(["bar" [1 :foo]] ["world" [0 :hello]]))
+  (select-by [:key "hello"] (m/match {:hello "world"})) => (m/create-match "world" [:hello])
+  (select-by [:key "hello"] (m/match [{:hello "foo"} {:hello "bar"}])) => (list (m/create-match "foo" [0 :hello]) (m/create-match "bar" [1 :hello]))
+  (select-by [:key "hello"] (m/match [{:blah "foo"} {:hello "bar"}])) => (list (m/create-match "bar" [1 :hello]))
+  (select-by [:key "*"] (m/match {:hello "world"})) => (list (m/create-match "world" [:hello]))
+  (sort-by first (select-by [:key "*"] (m/match {:hello "world" :foo "bar"}))) => (list (m/create-match "bar" [:foo]) (m/create-match "world" [:hello]))
+  (sort-by first (select-by [:key "*"] (m/match [{:hello "world"} {:foo "bar"}]))) => (list (m/create-match "bar" [1 :foo]) (m/create-match "world" [0 :hello])))
 
-(fact
-  (walk-path [[:root]] {:root (m/match ...root...), :current  (m/match ...obj...)}) => [...root... []]
-  (walk-path [[:root] [:child] [:key "foo"]] {:root (m/match {:foo "bar"})}) => ["bar" [:foo]]
-  (walk-path [[:key "foo"]] {:current (m/match [{:foo "bar"} {:foo "baz"} {:foo "qux"}])}) => '(["bar" [0 :foo]] ["baz" [1 :foo]] ["qux" [2 :foo]])
-  (walk-path [[:all-children]] {:current (m/match {:foo "bar" :baz {:qux "zoo"}})}) => '([{:foo "bar" :baz {:qux "zoo"}} []]
-                                                                                         [{:qux "zoo"} [:baz]])
+(facts
+  (walk-path [[:root]] {:root (m/match ...root...), :current  (m/match ...obj...)}) => (m/create-match ...root... [])
+  (walk-path [[:root] [:child] [:key "foo"]] {:root (m/match {:foo "bar"})}) => (m/create-match "bar" [:foo])
+  (walk-path [[:key "foo"]] {:current (m/match [{:foo "bar"} {:foo "baz"} {:foo "qux"}])}) => (list (m/create-match "bar" [0 :foo]) (m/create-match "baz" [1 :foo]) (m/create-match "qux" [2 :foo]))
+  (walk-path [[:all-children]] {:current (m/match {:foo "bar" :baz {:qux "zoo"}})}) => (list (m/create-match {:foo "bar" :baz {:qux "zoo"}} [])
+                                                                                             (m/create-match {:qux "zoo"} [:baz]))
   (distinct (walk-path [[:all-children] [:key "bar"]] ;; distinct works around dups, mentioned in https://github.com/gga/json-path/pull/6
-                       {:current (m/match '([{:bar "hello"}]))})) => '(["hello" [0 0 :bar]])
+                       {:current (m/match '([{:bar "hello"}]))})) => (list (m/create-match "hello" [0 0 :bar]))
   (walk-path [[:all-children] [:key "bar"]]
              {:current (m/match {:foo [{:bar "wrong"}
-                                       {:bar "baz"}]})}) => '(["wrong" [:foo 0 :bar]]
-                                                              ["baz" [:foo 1 :bar]])
+                                       {:bar "baz"}]})}) => (list (m/create-match "wrong" [:foo 0 :bar])
+                                                                  (m/create-match "baz" [:foo 1 :bar]))
   (walk-path [[:all-children] [:key "foo"]]
-             {:current (m/match {:foo [{:foo "foo"}]})}) => '([[{:foo "foo"}] [:foo]]
-                                                    ["foo" [:foo 0 :foo]]))
+             {:current (m/match {:foo [{:foo "foo"}]})}) => (list (m/create-match [{:foo "foo"}] [:foo])
+                                                                  (m/create-match "foo" [:foo 0 :foo])))
 
-(fact
-  (walk-selector [:index "1"] {:current (m/match ["foo", "bar", "baz"])}) => ["bar" [1]]
-  (walk-selector [:index "*"] {:current (m/match [:a :b])}) => '([:a [0]] [:b [1]])
+(facts
+  (walk-selector [:index "1"] {:current (m/match ["foo", "bar", "baz"])}) => (m/create-match "bar" [1])
+  (walk-selector [:index "*"] {:current (m/match [:a :b])}) => (list (m/create-match :a [0]) (m/create-match :b [1]))
   (walk-selector [:filter [:eq [:path [[:current] [:child] [:key "bar"]]] [:val "baz"]]]
-                 {:current (m/match [{:bar "wrong"} {:bar "baz"}])}) => '([{:bar "baz"} [1]]))
+                 {:current (m/match [{:bar "wrong"} {:bar "baz"}])}) => (list (m/create-match {:bar "baz"} [1])))
 
 (fact "selecting places constraints on the shape of the object being selected from"
   (walk-selector [:index "1"] {:current (m/match {:foo "bar"})}) => (throws Exception)
   (walk-selector [:index "*"] {:current (m/match {:foo "bar"})}) => (throws Exception))
 
 (facts
-  (walk [:path [[:root]]] {:root (m/match ...json...)}) => [...json... []]
-  (walk [:path [[:child]]] {:current (m/match ...json...)}) => [...json... []]
-  (walk [:path [[:current]]] {:current (m/match ...json...)}) => [...json... []]
-  (walk [:path [[:key "foo"]]] {:current (m/match {:foo "bar"})}) => ["bar" [:foo]]
+  (walk [:path [[:root]]] {:root (m/match ...json...)}) => (m/create-match ...json... [])
+  (walk [:path [[:child]]] {:current (m/match ...json...)}) => (m/create-match ...json... [])
+  (walk [:path [[:current]]] {:current (m/match ...json...)}) => (m/create-match ...json... [])
+  (walk [:path [[:key "foo"]]] {:current (m/match {:foo "bar"})}) => (m/create-match "bar" [:foo])
   (walk [:path [[:all-children]]]
         {:current
          (m/match {:hello {:world "foo"},
                    :baz {:world "bar",
-                         :quuz {:world "zux"}}})}) => '([{:hello {:world "foo"},
-                                                          :baz {:world "bar", :quuz {:world "zux"}}}
-                                                         []]
-                                                        [{:world "foo"}
-                                                         [:hello]]
-                                                        [{:world "bar",
-                                                          :quuz {:world "zux"}}
-                                                         [:baz]]
-                                                        [{:world "zux"}
-                                                         [:baz :quuz]])
+                         :quuz {:world "zux"}}})}) => (list (m/create-match {:hello {:world "foo"},
+                                                                             :baz {:world "bar", :quuz {:world "zux"}}}
+                                                                            [])
+                                                            (m/create-match {:world "foo"}
+                                                                            [:hello])
+                                                            (m/create-match {:world "bar",
+                                                                             :quuz {:world "zux"}}
+                                                                            [:baz])
+                                                            (m/create-match {:world "zux"}
+                                                                            [:baz :quuz]))
   (walk [:path [[:all-children]]]
         {:current
          (m/match (list {:hello {:world "foo"}}
-                        {:baz {:world "bar"}}))}) => '([[{:hello {:world "foo"}}
-                                                         {:baz {:world "bar"}}]
-                                                        []]
-                                                       [{:hello {:world "foo"}} [0]]
-                                                       [{:world "foo"} [0 :hello]]
-                                                       [{:baz {:world "bar"}} [1]]
-                                                       [{:world "bar"} [1 :baz]])
+                        {:baz {:world "bar"}}))}) => (list (m/create-match [{:hello {:world "foo"}}
+                                                                            {:baz {:world "bar"}}]
+                                                                           [])
+                                                           (m/create-match {:hello {:world "foo"}} [0])
+                                                           (m/create-match {:world "foo"} [0 :hello])
+                                                           (m/create-match {:baz {:world "bar"}} [1])
+                                                           (m/create-match {:world "bar"} [1 :baz]))
   (walk [:path [[:all-children]]]
-        {:current (m/match "scalar")}) => '(["scalar" []])
+        {:current (m/match "scalar")}) => (list (m/create-match "scalar" []))
   (walk [:path [[:all-children] [:key "world"]]]
         {:current (m/match {:hello {:world "foo"},
                             :baz   {:world "bar",
-                                    :quuz {:world "zux"}}})}) => '(["foo" [:hello :world]]
-                                                                   ["bar" [:baz :world]]
-                                                                   ["zux" [:baz :quuz :world]])
-  (walk [:selector [:index "1"]] {:current (m/match ["foo", "bar", "baz"])}) => ["bar" [1]]
-  (walk [:selector [:index "*"]] {:current (m/match [:a :b])}) => '([:a [0]] [:b [1]])
+                                    :quuz {:world "zux"}}})}) => (list (m/create-match "foo" [:hello :world])
+                                                                       (m/create-match "bar" [:baz :world])
+                                                                       (m/create-match "zux" [:baz :quuz :world]))
+  (walk [:selector [:index "1"]] {:current (m/match ["foo", "bar", "baz"])}) => (m/create-match "bar" [1])
+  (walk [:selector [:index "*"]] {:current (m/match [:a :b])}) => (list (m/create-match :a [0]) (m/create-match :b [1]))
   (walk [:selector [:index "*"]
          [:path [[:child] [:key "foo"]]]]
         {:current
-         (m/match [{:foo 1} {:foo 2}])}) => '([1 [0 :foo]] [2 [1 :foo]])
+         (m/match [{:foo 1} {:foo 2}])}) => (list (m/create-match 1 [0 :foo]) (m/create-match 2 [1 :foo]))
   (walk [:selector [:filter [:eq
                              [:path [[:current]
                                      [:child]
                                      [:key "bar"]]]
                              [:val "baz"]]]]
-        {:current (m/match [{:bar "wrong"} {:bar "baz"}])}) => '([{:bar "baz"} [1]])
+        {:current (m/match [{:bar "wrong"} {:bar "baz"}])}) => (list (m/create-match {:bar "baz"} [1]))
   (walk [:path [[:root] [:child] [:key "foo"]]
          [:selector [:filter [:eq [:path [[:current]
                                           [:child]
@@ -106,10 +106,10 @@
                               [:val "baz"]]]
           [:path [[:child] [:key "hello"]]]]]
         {:root (m/match {:foo [{:bar "wrong" :hello "goodbye"}
-                               {:bar "baz" :hello "world"}]})}) => '(["world" [:foo 1 :hello]]))
+                               {:bar "baz" :hello "world"}]})}) => (list (m/create-match "world" [:foo 1 :hello])))
 
 (facts "walking a nil object should be safe"
-  (walk [:path [[:root]]] {:root (m/match nil)}) => [nil []]
-  (walk [:path [[:root] [:child] [:key "foo"]]] {:root (m/match {:bar "baz"})}) => [nil [:foo]]
+  (walk [:path [[:root]]] {:root (m/match nil)}) => (m/create-match nil [])
+  (walk [:path [[:root] [:child] [:key "foo"]]] {:root (m/match {:bar "baz"})}) => (m/create-match nil [:foo])
   (walk [:path [[:root] [:child] [:key "foo"] [:child] [:key "bar"]]]
-           {:root (m/match {:foo {:baz "hello"}})}) => [nil [:foo :bar]])
+        {:root (m/match {:foo {:baz "hello"}})}) => (m/create-match nil [:foo :bar]))

--- a/test/json_path/test/walker_test.clj
+++ b/test/json_path/test/walker_test.clj
@@ -1,4 +1,5 @@
 (ns json-path.test.walker-test
+  [:require [json-path.match :as m]]
   [:use [json-path.walker]
    [midje.sweet]])
 
@@ -12,103 +13,103 @@
   (eval-expr [:lt-eq [:val 10] [:val 10]] {}) => truthy
   (eval-expr [:gt [:val 10] [:val 9]] {}) => truthy
   (eval-expr [:gt-eq [:val 10] [:val 10]] {}) => truthy
-  (eval-expr [:path [[:key "foo"]]] {:current {:foo "bar"}}) => "bar"
-  (eval-expr [:eq [:path [[:key "foo"]]] [:val "bar"]] {:current {:foo "bar"}}) => truthy)
+  (eval-expr [:path [[:key "foo"]]] {:current (m/match {:foo "bar"})}) => "bar"
+  (eval-expr [:eq [:path [[:key "foo"]]] [:val "bar"]] {:current (m/match {:foo "bar"})}) => truthy)
 
 (facts
-  (select-by [:key "hello"] {:current {:hello "world"}}) => ["world" [:hello]]
-  (select-by [:key "hello"] {:current [{:hello "foo"} {:hello "bar"}]}) => '(["foo" [0 :hello]] ["bar" [1 :hello]])
-  (select-by [:key "hello"] {:current [{:blah "foo"} {:hello "bar"}]}) => '(["bar" [1 :hello]])
-  (select-by [:key "*"] {:current {:hello "world"}}) => '(["world" [:hello]])
-  (sort-by first (select-by [:key "*"] {:current {:hello "world" :foo "bar"}})) => '(["bar" [:foo]] ["world" [:hello]])
-  (sort-by first (select-by [:key "*"] {:current [{:hello "world"} {:foo "bar"}]})) => '(["bar" [1 :foo]] ["world" [0 :hello]]))
+  (select-by [:key "hello"] (m/match {:hello "world"})) => ["world" [:hello]]
+  (select-by [:key "hello"] (m/match [{:hello "foo"} {:hello "bar"}])) => '(["foo" [0 :hello]] ["bar" [1 :hello]])
+  (select-by [:key "hello"] (m/match [{:blah "foo"} {:hello "bar"}])) => '(["bar" [1 :hello]])
+  (select-by [:key "*"] (m/match {:hello "world"})) => '(["world" [:hello]])
+  (sort-by first (select-by [:key "*"] (m/match {:hello "world" :foo "bar"}))) => '(["bar" [:foo]] ["world" [:hello]])
+  (sort-by first (select-by [:key "*"] (m/match [{:hello "world"} {:foo "bar"}]))) => '(["bar" [1 :foo]] ["world" [0 :hello]]))
 
 (fact
-  (walk-path [[:root]] {:root ...root..., :current  ...obj...}) => [...root... []]
-  (walk-path [[:root] [:child] [:key "foo"]] {:root {:foo "bar"}}) => ["bar" [:foo]]
-  (walk-path [[:key "foo"]] {:current [{:foo "bar"} {:foo "baz"} {:foo "qux"}]}) => '(["bar" [0 :foo]] ["baz" [1 :foo]] ["qux" [2 :foo]])
-  (walk-path [[:all-children]] {:current {:foo "bar" :baz {:qux "zoo"}}}) => '([{:foo "bar" :baz {:qux "zoo"}} []]
-                                                                               [{:qux "zoo"} [:baz]])
+  (walk-path [[:root]] {:root (m/match ...root...), :current  (m/match ...obj...)}) => [...root... []]
+  (walk-path [[:root] [:child] [:key "foo"]] {:root (m/match {:foo "bar"})}) => ["bar" [:foo]]
+  (walk-path [[:key "foo"]] {:current (m/match [{:foo "bar"} {:foo "baz"} {:foo "qux"}])}) => '(["bar" [0 :foo]] ["baz" [1 :foo]] ["qux" [2 :foo]])
+  (walk-path [[:all-children]] {:current (m/match {:foo "bar" :baz {:qux "zoo"}})}) => '([{:foo "bar" :baz {:qux "zoo"}} []]
+                                                                                         [{:qux "zoo"} [:baz]])
   (distinct (walk-path [[:all-children] [:key "bar"]] ;; distinct works around dups, mentioned in https://github.com/gga/json-path/pull/6
-                       {:current '([{:bar "hello"}])})) => '(["hello" [0 0 :bar]])
+                       {:current (m/match '([{:bar "hello"}]))})) => '(["hello" [0 0 :bar]])
   (walk-path [[:all-children] [:key "bar"]]
-             {:current {:foo [{:bar "wrong"}
-                              {:bar "baz"}]}}) => '(["wrong" [:foo 0 :bar]]
-                                                    ["baz" [:foo 1 :bar]])
+             {:current (m/match {:foo [{:bar "wrong"}
+                                       {:bar "baz"}]})}) => '(["wrong" [:foo 0 :bar]]
+                                                              ["baz" [:foo 1 :bar]])
   (walk-path [[:all-children] [:key "foo"]]
-             {:current {:foo [{:foo "foo"}]}}) => '([[{:foo "foo"}] [:foo]]
+             {:current (m/match {:foo [{:foo "foo"}]})}) => '([[{:foo "foo"}] [:foo]]
                                                     ["foo" [:foo 0 :foo]]))
 
 (fact
-  (walk-selector [:index "1"] {:current ["foo", "bar", "baz"]}) => ["bar" [1]]
-  (walk-selector [:index "*"] {:current [:a :b]}) => '([:a [0]] [:b [1]])
+  (walk-selector [:index "1"] {:current (m/match ["foo", "bar", "baz"])}) => ["bar" [1]]
+  (walk-selector [:index "*"] {:current (m/match [:a :b])}) => '([:a [0]] [:b [1]])
   (walk-selector [:filter [:eq [:path [[:current] [:child] [:key "bar"]]] [:val "baz"]]]
-                 {:current  [{:bar "wrong"} {:bar "baz"}]}) => '([{:bar "baz"} [1]]))
+                 {:current (m/match [{:bar "wrong"} {:bar "baz"}])}) => '([{:bar "baz"} [1]]))
 
 (fact "selecting places constraints on the shape of the object being selected from"
-  (walk-selector [:index "1"] {:current {:foo "bar"}}) => (throws Exception)
-  (walk-selector [:index "*"] {:current {:foo "bar"}}) => (throws Exception))
+  (walk-selector [:index "1"] {:current (m/match {:foo "bar"})}) => (throws Exception)
+  (walk-selector [:index "*"] {:current (m/match {:foo "bar"})}) => (throws Exception))
 
 (facts
-  (walk [:path [[:root]]] {:root ...json...}) => [...json... []]
-  (walk [:path [[:child]]] {:current ...json...}) => [...json... []]
-  (walk [:path [[:current]]] {:current ...json...}) => [...json... []]
-  (walk [:path [[:key "foo"]]] {:current {:foo "bar"}}) => ["bar" [:foo]]
+  (walk [:path [[:root]]] {:root (m/match ...json...)}) => [...json... []]
+  (walk [:path [[:child]]] {:current (m/match ...json...)}) => [...json... []]
+  (walk [:path [[:current]]] {:current (m/match ...json...)}) => [...json... []]
+  (walk [:path [[:key "foo"]]] {:current (m/match {:foo "bar"})}) => ["bar" [:foo]]
   (walk [:path [[:all-children]]]
         {:current
-         {:hello {:world "foo"},
-          :baz {:world "bar",
-                :quuz {:world "zux"}}}}) => '([{:hello {:world "foo"},
-                                                :baz {:world "bar", :quuz {:world "zux"}}}
-                                               []]
-                                              [{:world "foo"}
-                                               [:hello]]
-                                              [{:world "bar",
-                                                :quuz {:world "zux"}}
-                                               [:baz]]
-                                              [{:world "zux"}
-                                               [:baz :quuz]])
+         (m/match {:hello {:world "foo"},
+                   :baz {:world "bar",
+                         :quuz {:world "zux"}}})}) => '([{:hello {:world "foo"},
+                                                          :baz {:world "bar", :quuz {:world "zux"}}}
+                                                         []]
+                                                        [{:world "foo"}
+                                                         [:hello]]
+                                                        [{:world "bar",
+                                                          :quuz {:world "zux"}}
+                                                         [:baz]]
+                                                        [{:world "zux"}
+                                                         [:baz :quuz]])
   (walk [:path [[:all-children]]]
         {:current
-         (list {:hello {:world "foo"}}
-               {:baz {:world "bar"}})}) => '([[{:hello {:world "foo"}}
-                                               {:baz {:world "bar"}}]
-                                              []]
-                                             [{:hello {:world "foo"}} [0]]
-                                             [{:world "foo"} [0 :hello]]
-                                             [{:baz {:world "bar"}} [1]]
-                                             [{:world "bar"} [1 :baz]])
+         (m/match (list {:hello {:world "foo"}}
+                        {:baz {:world "bar"}}))}) => '([[{:hello {:world "foo"}}
+                                                         {:baz {:world "bar"}}]
+                                                        []]
+                                                       [{:hello {:world "foo"}} [0]]
+                                                       [{:world "foo"} [0 :hello]]
+                                                       [{:baz {:world "bar"}} [1]]
+                                                       [{:world "bar"} [1 :baz]])
   (walk [:path [[:all-children]]]
-        {:current "scalar"}) => '(["scalar" []])
+        {:current (m/match "scalar")}) => '(["scalar" []])
   (walk [:path [[:all-children] [:key "world"]]]
-        {:current {:hello {:world "foo"},
-                   :baz   {:world "bar",
-                           :quuz {:world "zux"}}}}) => '(["foo" [:hello :world]]
-                                                         ["bar" [:baz :world]]
-                                                         ["zux" [:baz :quuz :world]])
-  (walk [:selector [:index "1"]] {:current ["foo", "bar", "baz"]}) => ["bar" [1]]
-  (walk [:selector [:index "*"]] {:current [:a :b]}) => '([:a [0]] [:b [1]])
+        {:current (m/match {:hello {:world "foo"},
+                            :baz   {:world "bar",
+                                    :quuz {:world "zux"}}})}) => '(["foo" [:hello :world]]
+                                                                   ["bar" [:baz :world]]
+                                                                   ["zux" [:baz :quuz :world]])
+  (walk [:selector [:index "1"]] {:current (m/match ["foo", "bar", "baz"])}) => ["bar" [1]]
+  (walk [:selector [:index "*"]] {:current (m/match [:a :b])}) => '([:a [0]] [:b [1]])
   (walk [:selector [:index "*"]
          [:path [[:child] [:key "foo"]]]]
         {:current
-         [{:foo 1} {:foo 2}]}) => '([1 [0 :foo]] [2 [1 :foo]])
+         (m/match [{:foo 1} {:foo 2}])}) => '([1 [0 :foo]] [2 [1 :foo]])
   (walk [:selector [:filter [:eq
                              [:path [[:current]
                                      [:child]
                                      [:key "bar"]]]
                              [:val "baz"]]]]
-        {:current [{:bar "wrong"} {:bar "baz"}]}) => '([{:bar "baz"} [1]])
+        {:current (m/match [{:bar "wrong"} {:bar "baz"}])}) => '([{:bar "baz"} [1]])
   (walk [:path [[:root] [:child] [:key "foo"]]
          [:selector [:filter [:eq [:path [[:current]
                                           [:child]
                                           [:key "bar"]]]
                               [:val "baz"]]]
           [:path [[:child] [:key "hello"]]]]]
-        {:root {:foo [{:bar "wrong" :hello "goodbye"}
-                      {:bar "baz" :hello "world"}]}}) => '(["world" [:foo 1 :hello]]))
+        {:root (m/match {:foo [{:bar "wrong" :hello "goodbye"}
+                               {:bar "baz" :hello "world"}]})}) => '(["world" [:foo 1 :hello]]))
 
 (facts "walking a nil object should be safe"
-  (walk [:path [[:root]]] {:root nil}) => [nil []]
-  (walk [:path [[:root] [:child] [:key "foo"]]] {:root {:bar "baz"}}) => [nil [:foo]]
+  (walk [:path [[:root]]] {:root (m/match nil)}) => [nil []]
+  (walk [:path [[:root] [:child] [:key "foo"]]] {:root (m/match {:bar "baz"})}) => [nil [:foo]]
   (walk [:path [[:root] [:child] [:key "foo"] [:child] [:key "bar"]]]
-           {:root {:foo {:baz "hello"}}}) => [nil [:foo :bar]])
+           {:root (m/match {:foo {:baz "hello"}})}) => [nil [:foo :bar]])

--- a/test/json_path/test/walker_test.clj
+++ b/test/json_path/test/walker_test.clj
@@ -22,7 +22,7 @@
   (select-by [:key "hello"] (m/match [{:blah "foo"} {:hello "bar"}])) => (list (m/create-match "bar" [1 :hello]))
   (select-by [:key "*"] (m/match {:hello "world"})) => (list (m/create-match "world" [:hello]))
   (sort-by first (select-by [:key "*"] (m/match {:hello "world" :foo "bar"}))) => (list (m/create-match "bar" [:foo]) (m/create-match "world" [:hello]))
-  (sort-by first (select-by [:key "*"] (m/match [{:hello "world"} {:foo "bar"}]))) => (list (m/create-match "bar" [1 :foo]) (m/create-match "world" [0 :hello])))
+  (sort-by first (select-by [:key "*"] (m/match [{:hello "world"} {:foo "bar"}]))) => (list (m/create-match "world" [0 :hello]) (m/create-match "bar" [1 :foo])))
 
 (facts
   (walk-path [[:root]] {:root (m/match ...root...), :current  (m/match ...obj...)}) => (m/create-match ...root... [])


### PR DESCRIPTION
The original change to implement the `query` API tried to touch as little code as possible. In the end the old implementation that would pass along a subset of the original data was complemented by a mechanism, that would record the path after the recursive call returned. Basically one mechanism recording forward, one backward.

This change touches a lot of code on the surface but hopefully reduces the cognitive load required to understand what is going on: The data and the selected path are recorded together, and each sub-selection will just record the path descended into. So instead of bare object as value, we will not pass through a match record with both value and path.

I'm also changing the match exposed via `query` to be a record with `:path` and `:value` instead.