### PR TITLE
Fix for nested array selection

### DIFF
--- a/src/json_path/walker.clj
+++ b/src/json_path/walker.clj
@@ -16,7 +16,9 @@
 
 (defn map# [func obj]
   (if (seq? obj)
-    (map (partial map# func) obj)
+    (->> obj
+         (flatten)
+         (map (partial map# func)))
     (func obj)))
 
 (defn- select-all [current-context]

--- a/src/json_path/walker.clj
+++ b/src/json_path/walker.clj
@@ -16,7 +16,7 @@
 
 (defn map# [func obj]
   (if (seq? obj)
-    (map func obj)
+    (map (partial map# func) obj)
     (func obj)))
 
 (defn- select-all [current-context]

--- a/test/json_path/test/json_path_test.clj
+++ b/test/json_path/test/json_path_test.clj
@@ -24,7 +24,9 @@
                   {:bar "baz" :hello "world"}]}) => ["world"]
   (at-path "$.foo[?(@.id=$.id)].text"
            {:id 45, :foo [{:id 12, :text "bar"},
-                          {:id 45, :text "hello"}]}) => ["hello"])
+                          {:id 45, :text "hello"}]}) => ["hello"]
+  (at-path "$.foo[*].bar[*].baz"
+           {:foo [{:bar [{:baz "hello"}]}]}) => [["hello"]])
 
 (facts
   (-> (query "$.hello"

--- a/test/json_path/test/json_path_test.clj
+++ b/test/json_path/test/json_path_test.clj
@@ -26,7 +26,7 @@
            {:id 45, :foo [{:id 12, :text "bar"},
                           {:id 45, :text "hello"}]}) => ["hello"]
   (at-path "$.foo[*].bar[*].baz"
-           {:foo [{:bar [{:baz "hello"}]}]}) => [["hello"]])
+           {:foo [{:bar [{:baz "hello"}]}]}) => ["hello"])
 
 (facts
   (-> (query "$.hello"


### PR DESCRIPTION
Hi, I've been using this library, and I've noticed that it doesn't work as expected when you try to select elements from nested arrays. For example, if you run `(at-path "$.foo[*].bar[*].baz" {:foo [{:bar [{:baz "hello"}]}]})`, you get back `(nil)`. I'd expect the result to be `(("hello"))`. I've put together a quick fix in this PR, but it may not be the best way of tackling the problem.